### PR TITLE
Use graphql-go/handler to handle /graphql

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/graphql-go/graphql"
 	"strings"
+
+	"github.com/graphql-go/graphql"
 )
 
 var (
@@ -229,16 +230,3 @@ var (
 		},
 	)
 )
-
-func executeQuery(query string, schema graphql.Schema) *graphql.Result {
-	result := graphql.Do(graphql.Params{
-		Schema:        schema,
-		RequestString: query,
-	})
-
-	if len(result.Errors) > 0 {
-		fmt.Printf("Wrong result, unexpected errors: %v", result.Errors)
-	}
-
-	return result
-}

--- a/server.go
+++ b/server.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/graphql-go/handler"
 )
 
 func main() {
@@ -15,7 +17,13 @@ func main() {
 	http.HandleFunc("/api/midterms", midtermsHandler)
 	http.HandleFunc("/api/attendance", attendanceHandler)
 	http.HandleFunc("/api/exams", examsHandler)
-	http.HandleFunc("/graphql", graphqlHandler)
+
+	h := handler.New(&handler.Config{
+		Schema: &schema,
+		Pretty: true,
+	})
+
+	http.Handle("/graphql", h)
 
 	port := os.Getenv("PORT")
 	if port == "" {
@@ -64,11 +72,6 @@ func examsHandler(w http.ResponseWriter, r *http.Request) {
 	} else {
 		sendJsonResponse(w, ResponseAPI{nil, exams})
 	}
-}
-
-func graphqlHandler(w http.ResponseWriter, r *http.Request) {
-	result := executeQuery(r.URL.Query()["query"][0], schema)
-	sendJsonResponse(w, result)
 }
 
 func basicAuthentication(r *http.Request) (string, string) {


### PR DESCRIPTION
 Use `github.com/graphql-go/handler` to handle `/graphql` requests instead of doing it manually, this also gives us support for `POST` requests which is mandatory for Apollo client. 
`GET` requests still work, though.